### PR TITLE
Master

### DIFF
--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -102,7 +102,7 @@ export default Service.extend({
     this.set('lastEvent', event);
 
     if (!this.get('isMoving') && this.get('currentDragEvent')) {
-      if (event.target !== this.get('currentDragEvent').target && hasSameSortingScope) { //if not dragging over self
+      if (event.target !== this.get('currentDragEvent').target) { //if not dragging over self
         if (currentOffsetItem !== emberObject) {
           if (pos.py < 0.67 && moveDirections.indexOf('up') >= 0 ||
               pos.py > 0.33 && moveDirections.indexOf('down') >= 0 ||


### PR DESCRIPTION
Remove scope check as we don't need scope check. And this scope checks that it is not working properly when drag drops from one list to another list.